### PR TITLE
New cuda docker version

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,6 +1,5 @@
-FROM nvidia/cuda:11.3-devel-centos8
+FROM nvidia/cuda:11.4.1-devel-centos8
 
-RUN dnf update
 RUN yum -y install dnf-plugins-core
 RUN dnf config-manager --set-enabled powertools
 RUN dnf --enablerepo=powertools -y install \
@@ -18,7 +17,7 @@ RUN dnf --enablerepo=powertools -y install \
 RUN mkdir -p /tmp/cmake && \
     cd /tmp/cmake && \
     wget 'https://cmake.org/files/v3.20/cmake-3.20.2.tar.gz' && \
-    tar -xzf cmake-3.20.0.tar.gz && \
+    tar -xzf cmake-3.20.2.tar.gz && \
     cd /tmp/cmake/cmake-3.20.2 && \
     ./bootstrap --prefix=/usr/local && \
     make -j$(nproc) && \


### PR DESCRIPTION
old version does not have manifest any longer, therefore update to newer version
dnf update did not run through, hence removed. Is that necessary?

also fix in cmake tar command